### PR TITLE
Invert order direction only

### DIFF
--- a/ManusAI.mq5
+++ b/ManusAI.mq5
@@ -286,7 +286,7 @@ double CalculateLot()
 //--- abre posicao
 bool OpenPosition(bool buy)
 {
-   // INVERT-SIGNAL: troca Buy↔Sell e SL↔TP
+   // INVERTED ENTRY LOGIC
    bool orderBuy = !buy;
 
    int    stopLevelPoints = (int)SymbolInfoInteger(_Symbol, SYMBOL_TRADE_STOPS_LEVEL);
@@ -296,16 +296,13 @@ bool OpenPosition(bool buy)
    double stopLevel = stopLevelPoints * point;
    double minDist   = MathMax(stopLevel, freezePts * point);
 
-   double sl_orig = buy ? NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_BID) - InpStopLossPips * point, _Digits)
-                        : NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_ASK) + InpStopLossPips * point, _Digits);
-   double tp_orig = buy ? NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_BID) + InpTakeProfitPips * point, _Digits)
-                        : NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_ASK) - InpTakeProfitPips * point, _Digits);
-
-   double sl = tp_orig;
-   double tp = sl_orig;
+   double sl = buy ? NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_BID) - InpStopLossPips * point, _Digits)
+                   : NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_ASK) + InpStopLossPips * point, _Digits);
+   double tp = buy ? NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_BID) + InpTakeProfitPips * point, _Digits)
+                   : NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_ASK) - InpTakeProfitPips * point, _Digits);
 
    // FIX: Invalid stops
-   if(orderBuy)
+   if(buy)
    {
       if ((SymbolInfoDouble(_Symbol, SYMBOL_BID) - sl) < minDist)
          sl = NormalizeDouble(SymbolInfoDouble(_Symbol, SYMBOL_BID) - minDist, _Digits);


### PR DESCRIPTION
## Summary
- adjust `OpenPosition` to flip trade direction but keep the original SL/TP

## Testing
- `python3 montecarlo_backtest.py -h`
- `python3 -m py_compile montecarlo_backtest.py`


------
https://chatgpt.com/codex/tasks/task_e_686bf13391648331b38c2627d17885c3